### PR TITLE
Fixes bug where GameClock wouldn't update

### DIFF
--- a/gfx/demos/SimpleGfx.cpp
+++ b/gfx/demos/SimpleGfx.cpp
@@ -113,7 +113,7 @@ int _main(core::PlatformLoop & loop) {
 		gl::bind_buffer(GL_ARRAY_BUFFER, vertex_pos_object);
 		gl::vertex_attrib_pointer(_screen.a_position, 3, GL_FLOAT, 0, 0, 0);
 
-		gl::enable_vertext_attrib_array(_screen.a_position);
+		gl::enable_vertex_attrib_array(_screen.a_position);
 		gl::draw_arrays(GL_TRIANGLES, 0, 3);
 
 		// GLfloat red[4] = { 1.0, 0.0f, 0.0f, 1.0f };

--- a/gfx/include/lp3/gfx/buffers.hpp
+++ b/gfx/include/lp3/gfx/buffers.hpp
@@ -45,6 +45,9 @@ public:
         return vertex_pos_object;
     }
 
+	// Resets the buffer so it can be reused.
+	void reset();
+
     std::size_t size() const {
         return vertices.size();
     }
@@ -68,6 +71,9 @@ public:
     inline void push_back(GLushort value) {
         elements.push_back(value);
     }
+
+	// Clears all elements
+	void reset(); 
 
     inline GLsizei size() const {
         return GLsizei(elements.size());
@@ -145,6 +151,12 @@ public:
 
 		QuadArray<Vertex> array(data, count);
 		return array;
+	}
+
+	// Reset the buffers in order to write again.
+	void reset() {
+		vertices.reset();
+		elements.reset();
 	}
 
     void transfar() const {

--- a/gfx/include/lp3/gfx/programs/SimpleTextured.hpp
+++ b/gfx/include/lp3/gfx/programs/SimpleTextured.hpp
@@ -9,8 +9,8 @@
 namespace lp3 { namespace gfx { namespace programs {
 
 
-class 
-LP3_GFX_API 
+class
+LP3_GFX_API
 SimpleTextured {
 public:
 
@@ -26,7 +26,6 @@ public:
     const gl::VertexAttributeIndex a_texCoord{ 1 };
 
     // Name of mvp variable
-
 
     // Get variable of u mvp (MUST BE USING PROGRAM).
     gl::UniformVariableLocation get_u_mvp() const;
@@ -46,6 +45,9 @@ public:
     void set_mvp(const glm::mat4 & previous) const;
 
     void set_texture(const gl::TextureID & id) const;
+
+    // Disables array buffer variables.
+    void unset_array_buffer() const;
 
     void draw(const ElementWriter<TexVert> & elements) const;
 private:

--- a/gfx/src/CPaper.cpp
+++ b/gfx/src/CPaper.cpp
@@ -150,7 +150,7 @@ void CPaper::RendererList::render(const CPaper & cpaper) const {
 	// Setup the position attribute to accept a pointer to the buffer.
 	gl::bind_buffer(GL_ARRAY_BUFFER, vertex_pos_object);
 	gl::vertex_attrib_pointer(cpaper.a_position, 3, GL_FLOAT, 0, 0, 0);
-	gl::enable_vertext_attrib_array(cpaper.a_position);
+	gl::enable_vertex_attrib_array(cpaper.a_position);
 
 	for (std::size_t i = 0; i < colors.size(); ++i) {
 		GLfloat color[4];

--- a/gfx/src/buffers.cpp
+++ b/gfx/src/buffers.cpp
@@ -30,6 +30,13 @@ GLfloat * FloatBuffer::claim(const int size) {
 }
 
 LP3_GFX_API
+void FloatBuffer::reset() {
+	const auto s = this->size();
+	vertices.clear();
+	vertices.reserve(s);
+}
+
+LP3_GFX_API
 void FloatBuffer::transfar() const {
     // Copy data from client side to graphics land.
     // If the vertices change at all this must happen again.
@@ -46,6 +53,10 @@ ElementBuffer::ElementBuffer()
 {
     // Create the buffer to be used by OpenGL.(GLSL) (Bunny Link)
     vertex_index_object = gl::gen_buffer();
+}
+
+void ElementBuffer::reset() {
+	elements.clear();
 }
 
 void ElementBuffer::transfar() const {

--- a/gfx/src/programs/SimpleTextured.cpp
+++ b/gfx/src/programs/SimpleTextured.cpp
@@ -103,15 +103,17 @@ void SimpleTextured::set_array_buffer(gl::BufferObjectName vertex_pos_object) co
         5 * sizeof(GLfloat),
         (const void *) (3 * sizeof(GLfloat))
     );
-    gl::enable_vertext_attrib_array(this->a_position);
-    gl::enable_vertext_attrib_array(this->a_texCoord);
+    gl::enable_vertex_attrib_array(this->a_position);
+    gl::enable_vertex_attrib_array(this->a_texCoord);
 }
 
+LP3_GFX_API
 void SimpleTextured::set_mvp(const glm::mat4 & mvp) const {
     const gl::UniformVariableLocation u_ortho_index = get_u_mvp();
     gl::uniform_matrix_4fv(u_ortho_index, const_cast<glm::mat4 &>(mvp));
 }
 
+LP3_GFX_API
 void SimpleTextured::set_texture(const gl::TextureID & id) const {
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, id);
@@ -124,11 +126,19 @@ void SimpleTextured::set_texture(const gl::TextureID & id) const {
     glUniform1i(get_s_texture(), 0);
 }
 
+LP3_GFX_API
+void SimpleTextured::unset_array_buffer() const {
+    gl::disable_vertex_attrib_array(this->a_position);
+    gl::disable_vertex_attrib_array(this->a_texCoord);
+}
+
+LP3_GFX_API
 void SimpleTextured::draw(const ElementWriter<TexVert> & elements) const {
     elements.transfar();
     // Setup the position attribute to accept a pointer to the buffer.
     this->set_array_buffer(elements.vertices_attribute());
     glDrawElements(GL_TRIANGLES, elements.count(), GL_UNSIGNED_SHORT, 0);
+    this->unset_array_buffer();
 }
 
 }   }   }

--- a/gl/demos/glDemo.cpp
+++ b/gl/demos/glDemo.cpp
@@ -92,7 +92,7 @@ int _main(core::PlatformLoop & loop) {
 
         gl::bind_buffer(GL_ARRAY_BUFFER, vertex_pos_object);		
         gl::vertex_attrib_pointer(v_position, 3, GL_FLOAT, 0, 0, 0);
-        gl::enable_vertext_attrib_array(v_position);
+        gl::enable_vertex_attrib_array(v_position);
         gl::draw_arrays(GL_TRIANGLES, 0, 3);
 
         SDL_GL_SwapWindow(window);

--- a/gl/include/lp3/gl/extras.hpp
+++ b/gl/include/lp3/gl/extras.hpp
@@ -183,9 +183,14 @@ inline void draw_arrays(GLenum mode, GLint first, GLsizei count) {
 	LP3_GL_ASSERT_NO_ERRORS();
 }
 
-inline void enable_vertext_attrib_array(VertexAttributeIndex index) {
+inline void enable_vertex_attrib_array(VertexAttributeIndex index) {
 	glEnableVertexAttribArray(index);
 	LP3_GL_ASSERT_NO_ERRORS();
+}
+
+inline void disable_vertex_attrib_array(VertexAttributeIndex index) {
+    glDisableVertexAttribArray(index);
+    LP3_GL_ASSERT_NO_ERRORS();
 }
 
 template<std::size_t size>

--- a/sims/include/lp3/sims/Clock.hpp
+++ b/sims/include/lp3/sims/Clock.hpp
@@ -168,6 +168,7 @@ private:
 private:
     std::int64_t current_time;
     std::int64_t lag;
+    std::int64_t max_lag;
     std::int64_t update_time_in_ms;
     std::int64_t previous_time;
     Timer timer;

--- a/sims/src/Clock.cpp
+++ b/sims/src/Clock.cpp
@@ -68,6 +68,7 @@ LP3_SIMS_API
 GameClock::GameClock(Timer::time_int logic_update_time_in_ms)
 :   current_time(0),
     lag(0),
+    max_lag(std::max(500ll, logic_update_time_in_ms)),
     update_time_in_ms(logic_update_time_in_ms),
     previous_time(0),
     timer()
@@ -109,8 +110,8 @@ std::int64_t GameClock::start_frame() {
     // the real loop can't go at least that fast, the game will noticably
     // slow down.  However it beats the alternative, which would make the
     // app increasingly unresponsive.
-    if (lag > 500) {
-        lag = 500;
+    if (lag > max_lag) {
+        lag = max_lag;
     }
 
     return lag;

--- a/sims/src/Clock.cpp
+++ b/sims/src/Clock.cpp
@@ -68,7 +68,7 @@ LP3_SIMS_API
 GameClock::GameClock(Timer::time_int logic_update_time_in_ms)
 :   current_time(0),
     lag(0),
-    max_lag(std::max(500ll, logic_update_time_in_ms)),
+    max_lag(std::max(Timer::time_int{500}, logic_update_time_in_ms)),
     update_time_in_ms(logic_update_time_in_ms),
     previous_time(0),
     timer()


### PR DESCRIPTION
If GameClock was given a granularity over 500 it would never update,
due to a test for a maximum that was capped at 500. Now there's a
mag lag value set on construction to allow for this.