### PR TITLE
Force `/subsystem:windows` flag in main.hpp

### DIFF
--- a/core/include/lp3/core/utils.hpp
+++ b/core/include/lp3/core/utils.hpp
@@ -26,6 +26,8 @@ class
 LP3_CORE_API
 PlatformLoop {
 public:
+    PlatformLoop();
+
     PlatformLoop(int argc, char ** argv);
 
     PlatformLoop(const PlatformLoop & other) = delete;

--- a/core/src/js/platform.cpp
+++ b/core/src/js/platform.cpp
@@ -21,6 +21,13 @@ namespace {
 
 }
 
+PlatformLoop::PlatformLoop()
+:   arguments()
+{
+    SDL_assert(global_instances < 1);
+    ++global_instances;
+}
+
 PlatformLoop::PlatformLoop(int argc, char ** argv)
 :   arguments()
 {
@@ -30,7 +37,6 @@ PlatformLoop::PlatformLoop(int argc, char ** argv)
     for (int i = 0; i < argc; i++) {
         this->arguments.push_back(argv[i]);
     }
-
 }
 
 std::vector<std::string> PlatformLoop::command_line_args() const {

--- a/core/src/media.cpp
+++ b/core/src/media.cpp
@@ -23,7 +23,7 @@ namespace lp3 { namespace core {
 
 namespace {
 	std::string get_env_media_path() {
-		return lp3::core::get_env_var("LP3_ROOT_PATH").get_value_or("");
+		return lp3::core::get_env_var("LP3_ROOT_PATH").get_value_or("./");
 	}
 }
 

--- a/core/src/pc/platform.cpp
+++ b/core/src/pc/platform.cpp
@@ -1,6 +1,8 @@
 #include <lp3/core/utils.hpp>
 #include <boost/lexical_cast.hpp>
-
+#ifdef LP3_COMPILE_TARGET_WINDOWS
+    #include <windows.h>
+#endif
 
 namespace lp3 { namespace core {
 
@@ -12,6 +14,28 @@ namespace {
         else
             return boost::lexical_cast<int>(*value);
     }
+}
+
+PlatformLoop::PlatformLoop()
+:   arguments()
+{
+    #if defined(LP3_COMPILE_TARGET_WINDOWS)
+        int argLength;
+        LPWSTR * windowsString = ::CommandLineToArgvW(GetCommandLineW(),
+                                                      &argLength);
+        if (nullptr == windowsString)
+        {
+            LP3_LOG_ERROR("Error converting command line arguments.");
+			LP3_THROW2(lp3::core::Exception, 
+				       "Error converting command line arguments.");
+        }
+        for(int i = 0; i < argLength; i ++)
+        {
+            WCharToCharConverter original(windowsString[i]);
+            this->arguments.push_back(original.GetCharPtr());
+        }
+        LocalFree(windowsString);
+    #endif
 }
 
 PlatformLoop::PlatformLoop(int argc, char ** argv)


### PR DESCRIPTION
Turns out not doing this was causing apps to not use game controllers
in Steam Link.